### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,5 +1,8 @@
 name: PHPStan
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/leMaur/php-url-checker/security/code-scanning/2](https://github.com/leMaur/php-url-checker/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow for limiting the permissions of the `GITHUB_TOKEN`. The minimal permissions required for this workflow are `contents: read`, as the workflow only needs to access repository files for the tasks like code checkout and running PHPStan. 

The fix involves:
1. Adding a `permissions` block at the root of the workflow configuration file (`.github/workflows/phpstan.yml`) to apply consistent permissions across all jobs in the workflow. This ensures the principle of least privilege is adhered to.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
