### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/leMaur/php-url-checker/security/code-scanning/1](https://github.com/leMaur/php-url-checker/security/code-scanning/1)

To fix the problem, we need to add an explicit `permissions` block to the workflow. The permissions should be set at the root level to apply to all jobs in the workflow since the highlighted issue is related to the workflow's lack of permissions. Based on the operations in the workflow, the minimal required permissions appear to involve reading repository contents (`contents: read`). No write permissions (e.g., `pull-requests: write`) are necessary as the workflow only runs tests and does not modify the repository.

The `permissions` block will be added at the root level, immediately below the `name` key in the YAML file. This ensures that all jobs inherit these minimal permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
