### PR TITLE
Add maxRedirects guard to UrlChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ composer require lemaur/php-url-checker
 The class `Lemaur\UrlChecker\UrlChecker` provides a static method `check` where accepts the URL to check as first parameter
 and the user agent string as a second parameter.  
 
+Redirects (`301`, `302`, `307`, `308`) are followed automatically, up to `maxRedirects` hops
+(default `5`). Set `maxRedirects: 0` to return the redirect response without following it.
+
 Here you can see how to use it 👇
 
 ```php
@@ -49,6 +52,7 @@ $response = UrlChecker::check(
     userAgent: 'MyApp/1.0 (UrlChecker)',
     connectTimeout: 5,
     timeout: 10,
+    maxRedirects: 5,
 );
 // \Lemaur\UrlChecker\DataTransferObject\CheckData
 

--- a/src/UrlChecker.php
+++ b/src/UrlChecker.php
@@ -17,6 +17,13 @@ use Psr\Http\Message\ResponseInterface;
 final class UrlChecker
 {
     /**
+     * Default maximum number of redirect hops to follow before giving up
+     * and returning the last redirect response as-is. Guards against
+     * redirect loops causing unbounded recursion.
+     */
+    public const DEFAULT_MAX_REDIRECTS = 5;
+
+    /**
      * @var array<Response>
      */
     private static array $queue = [];
@@ -29,10 +36,10 @@ final class UrlChecker
         self::$queue = $queue;
     }
 
-    public static function check(string $url, ?string $userAgent = null, ?int $connectTimeout = null, ?int $timeout = null): CheckData
+    public static function check(string $url, ?string $userAgent = null, ?int $connectTimeout = null, ?int $timeout = null, ?int $maxRedirects = null): CheckData
     {
         try {
-            $response = (new self())->getResponse($url, $userAgent, $connectTimeout, $timeout);
+            $response = (new self())->getResponse($url, $userAgent, $connectTimeout, $timeout, $maxRedirects ?? self::DEFAULT_MAX_REDIRECTS);
 
             if (!$response instanceof ResponseInterface) {
                 return new CheckData(
@@ -81,7 +88,7 @@ final class UrlChecker
     /**
      * @throws GuzzleException
      */
-    private function getResponse(string $url, ?string $userAgent = null, ?int $connectTimeout = null, ?int $timeout = null): ?ResponseInterface
+    private function getResponse(string $url, ?string $userAgent = null, ?int $connectTimeout = null, ?int $timeout = null, int $redirectsLeft = self::DEFAULT_MAX_REDIRECTS): ?ResponseInterface
     {
         $response = null;
 
@@ -111,8 +118,14 @@ final class UrlChecker
             }
         }
 
-        if (in_array($response?->getStatusCode(), [301, 302, 307, 308], strict: true)) {
-            return $this->getResponse($response->getHeader('Location')[0] ?? '');
+        if ($redirectsLeft > 0 && in_array($response?->getStatusCode(), [301, 302, 307, 308], strict: true)) {
+            return $this->getResponse(
+                $response->getHeader('Location')[0] ?? '',
+                $userAgent,
+                $connectTimeout,
+                $timeout,
+                $redirectsLeft - 1,
+            );
         }
 
         return $response;

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -25,3 +25,24 @@ it('returns status code and reason phrase', function ($statusCode, $reasonPhrase
     'status code 502' => [502, 'Bad Gateway'],
     'status code 503' => [503, 'Service Unavailable'],
 ]);
+
+it('stops following redirects after the maximum number of hops', function (int $statusCode): void {
+    // In fake mode every hop re-serves the same queued response, so a redirect
+    // status code recurses indefinitely unless the maxRedirects guard stops it.
+    UrlChecker::fake([new Response($statusCode, ['Location' => 'https://foo.bar/loop'])]);
+
+    expect(UrlChecker::check('https://foo.bar'))
+        ->statusCode->toBe($statusCode);
+})->with([
+    'moved permanently 301' => [301],
+    'found 302' => [302],
+    'temporary redirect 307' => [307],
+    'permanent redirect 308' => [308],
+]);
+
+it('does not follow redirects when maxRedirects is zero', function (): void {
+    UrlChecker::fake([new Response(301, ['Location' => 'https://foo.bar/elsewhere'])]);
+
+    expect(UrlChecker::check('https://foo.bar', maxRedirects: 0))
+        ->statusCode->toBe(301);
+});


### PR DESCRIPTION
## What

Adds a `maxRedirects` guard to `UrlChecker` to bound redirect-following.

## Why

`getResponse()` followed `301`/`302`/`307`/`308` redirects recursively with **no depth cap and no cycle guard** — a redirect loop could recurse until PHP hit its memory/stack limit. The recursive hop also silently dropped the caller's `userAgent`/`connectTimeout`/`timeout`.

## Changes

- New public const `UrlChecker::DEFAULT_MAX_REDIRECTS = 5` (untyped, to preserve the package's `php: ^8.1` support — typed class constants are 8.3+).
- `check()` gains a trailing, backward-compatible `?int $maxRedirects = null` parameter. `maxRedirects: 0` returns the redirect response without following it.
- `getResponse()` threads a `redirectsLeft` budget through the recursion, stops once exhausted (returning the last 3xx response), and now **preserves the caller's user-agent and timeouts on every hop**.
- README documents the redirect behavior and the new parameter.

## Tests

5 new Pest cases: each of `301`/`302`/`307`/`308` must terminate (in fake mode every hop re-serves the same response, so without the guard the suite would hang — a genuine regression test), plus a `maxRedirects: 0` no-follow case.

Local gates: `pest` 17 pass / 29 assertions, `phpstan analyse` no errors, `pint --test` passed.