### PR TITLE
chore: drop EOL PHP 8.1, modernize test toolchain

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
     ],
     "homepage": "https://github.com/lemaur/php-url-checker",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42",
         "laravel/pint": "^1.0",
-        "pestphp/pest": "^2.20",
+        "pestphp/pest": "^2.36",
         "pestphp/pest-plugin-type-coverage": "^2.8",
         "phpstan/phpstan": "^1.10",
         "rector/rector": "^1.0",


### PR DESCRIPTION
## Why

CI on `main` no longer resolves dependencies on a fresh install. PHP 8.1 reached **end-of-life** (security support ended Dec 2025), and the current Pest/PHPUnit toolchain has dropped it:

- `pestphp/pest` 2.36.1+ requires `php ^8.2`.
- The only 8.1-compatible Pest (`2.36.0`) needs a PHPUnit that `roave/security-advisories` now prunes as vulnerable.

So every `8.1` matrix leg fails at `composer install` — unrelated to any code change. This realigns the toolchain with the supported PHP versions.

## Changes

- `composer.json`: require `php ^8.2` (was `^8.1`); bump `pestphp/pest` to `^2.36`.
- `run-tests.yml` matrix: `[8.4, 8.3, 8.2]` (drop 8.1, add 8.4 for forward coverage).
- `phpstan.yml`: run on PHP 8.2 (was 8.1).

## Verification

Resolution confirmed locally (platform-pinned) for **8.2 / 8.3 / 8.4 × prefer-lowest / prefer-stable** — all resolve. Local gates green: `pest --ci` exit 0, `phpstan analyse` no errors, `pint --test` passed.

## ⚠️ Breaking change

Drops PHP 8.1 support → the next release should be **2.0.0**. Consistent with the EOL-PHP drops in `eloquent-publishing 4.0.0` and `markdown 3.0.0`.