### PR TITLE
chore: SHA-pin all actions + gate Dependabot auto-merge on tests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,32 +2,54 @@ name: dependabot-auto-merge
 on: pull_request_target
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-merge Dependabot PRs for semver-minor updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+      # Gate auto-merge on the test suite passing, then merge.
+      #
+      # We deliberately do NOT rely on branch protection / required status
+      # checks: fix-php-code-style-issues.yml and update-changelog.yml push
+      # directly to main via git-auto-commit-action, and required checks on
+      # main would block those pushes. Instead we wait for the test workflow
+      # run on this PR's head SHA to finish, and only merge if it succeeded.
+      # Only semver-minor and semver-patch updates are auto-merged; majors
+      # require manual review.
+      - name: Auto-merge minor/patch updates after tests pass
+        if: ${{ contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Auto-merge Dependabot PRs for semver-patch updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          ok=false
+          for _ in $(seq 1 40); do
+            run=$(gh run list --repo "$REPO" --workflow run-tests.yml --limit 30 \
+                    --json headSha,status,conclusion \
+                    --jq "[.[] | select(.headSha == \"$HEAD_SHA\")][0] // {}")
+            status=$(printf '%s' "$run" | jq -r '.status // "queued"')
+            if [ "$status" = "completed" ]; then
+              [ "$(printf '%s' "$run" | jq -r '.conclusion')" = "success" ] && ok=true
+              break
+            fi
+            echo "waiting for test suite (status=${status})…"
+            sleep 30
+          done
+          if [ "$ok" != "true" ]; then
+            echo "::error::Test suite did not pass for ${HEAD_SHA}; not auto-merging."
+            exit 1
+          fi
+          gh pr merge --merge "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -52,4 +52,6 @@ jobs:
             echo "::error::Test suite did not pass for ${HEAD_SHA}; not auto-merging."
             exit 1
           fi
-          gh pr merge --merge "$PR_URL"
+          # --match-head-commit refuses the merge if Dependabot rebased the PR
+          # after we validated HEAD_SHA, so we never merge an untested head.
+          gh pr merge --merge --match-head-commit "$HEAD_SHA" "$PR_URL"

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,18 +16,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.head_ref }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
 
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,18 +14,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
## Why

Supply-chain + consistency pass to bring php-url-checker to parity with `eloquent-publishing` (PR #37) and `markdown` (PR #21). A mutable action tag (`@v6`) lets a compromised or force-pushed upstream tag run arbitrary code in CI with the workflow token; a full-length commit SHA removes that primitive.

## Changes

**SHA-pin all 11 `uses:` refs** (tag kept as a trailing `# comment`). Every SHA was resolved via `gh api repos/OWNER/REPO/commits/TAG` and is identical to the pins already in `eloquent-publishing`:

| Action | Pin |
|--------|-----|
| `actions/checkout` | `de0fac2…` # v6 |
| `shivammathur/setup-php` | `7c071df…` # v2 |
| `aglipanci/laravel-pint-action` | `36de00d…` # 2.6 |
| `stefanzweifel/git-auto-commit-action` | `04702ed…` # v7 |
| `ramsey/composer-install` | `5c2bcf2…` # v4 |
| `stefanzweifel/changelog-updater-action` | `a938690…` # v1 |
| `dependabot/fetch-metadata` | `25dd0e3…` # v3.1.0 |

**Rewrite `dependabot-auto-merge.yml`** to wait for `run-tests.yml` to pass on the PR head SHA before merging (minor/patch only; majors stay manual). Previously it merged via `--auto` without gating on the suite.

## Deliberately NOT included: branch protection

`fix-php-code-style-issues.yml` and `update-changelog.yml` push directly to `main` via `git-auto-commit-action`. Required status checks / branch protection on `main` would block those pushes (the documented livewire-flux-mcp trap). Auto-merge therefore polls the test run instead of relying on required checks. Both sibling repos take the same approach — leaving `main` unprotected is the consistent choice for this git-auto-commit architecture.

## Scope

No source changes — `.github/workflows/` only. Verified clean: `composer audit` (no advisories), `gitleaks` (no leaks), secret grep (clean).