### PR TITLE
fix(ci): code-style check-only (no codebase mutation)

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,12 +1,13 @@
-name: Fix PHP code style issues
+name: Check PHP code style
 
+# CI check ONLY — fails if there are style violations, never mutates the codebase.
+# Developers fix style locally (`pint`) and push; CI just verifies. No workflow
+# commits back to a branch; the changelog updater is the sole permitted mutator.
 on:
-  push:
-    paths:
-      - '**.php'
+  pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   php-code-styling:
@@ -16,13 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.head_ref }}
 
-      - name: Fix PHP code style issues
+      - name: Check PHP code style (fail on violations, no changes)
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
-          commit_message: Fix styling
+          testMode: true


### PR DESCRIPTION
CI style checks must fail on violations, not auto-fix and commit. Now runs in testMode (contents: read).