### PR TITLE
chore(ci): add Composer malware + advisory audit gate

### DIFF
--- a/.github/workflows/composer-security.yml
+++ b/.github/workflows/composer-security.yml
@@ -1,0 +1,36 @@
+# managed-by: ComposerSecurityStamp (profile=oss) — edit the stamp, not this file
+name: Composer Security
+
+permissions:
+  contents: read
+
+on:
+  push:
+    paths:
+      - 'composer.json'
+      - '.github/workflows/composer-security.yml'
+  pull_request:
+  schedule:
+    - cron: '27 6 * * 1'  # weekly — catches deps newly flagged in an unchanged lockfile
+
+jobs:
+  audit:
+    name: Malware & advisory audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup PHP + pinned Composer
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: '8.4'
+          tools: composer:2.10
+          coverage: none
+
+      - name: Resolve dependencies (library ships no lock)
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Audit (Composer >= 2.10 fails on malware + advisories)
+        run: composer audit

--- a/composer.json
+++ b/composer.json
@@ -49,13 +49,25 @@
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
         },
+        "policy": {
+            "advisories": {
+                "block": true
+            },
+            "malware": {
+                "block": true,
+                "block-scope": "all"
+            },
+            "abandoned": {
+                "audit": "report"
+            }
+        },
         "sort-packages": true
     },
     "scripts": {
         "post-autoload-dump": "composer normalize",
+        "analyse": "vendor/bin/phpstan analyse",
         "format": "vendor/bin/pint",
         "refactor": "vendor/bin/rector process",
-        "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test:coverage": "vendor/bin/pest --coverage",
         "test:type": "vendor/bin/pest --type-coverage --log-junit=build/type-coverage.xml"


### PR DESCRIPTION
## What

Adds a dedicated **Composer Security** workflow that audits dependencies for known malware and security advisories, kept separate from the build/test pipeline.

## Why

Composer 2.10+ fails `composer audit` on packages flagged as malware or carrying a published advisory. Running this as its own gate means a feed flagging a dependency is surfaced as a clear, single-purpose check — and a weekly schedule catches advisories published *after* a dependency set was last touched, without needing a new commit.

## Details

- New `.github/workflows/composer-security.yml`:
  - runs on pushes that touch dependencies, on pull requests, and weekly via cron
  - Composer pinned to `2.10`; GitHub Actions pinned by commit SHA
  - read-only token (`contents: read`)
  - `composer update` (this is a library and ships no lockfile)
- `composer.json` gains a `config.policy` block: block on malware and advisories, report (don't fail) on abandoned packages.

## Verification

- `composer validate --strict` → valid
- `composer audit` on `main` → no security vulnerability advisories (the two abandoned `sebastian/*` dev dependencies are reported, not failing, by policy)