### PR TITLE
docs(ci): correct stale rationale comment in dependabot-auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,10 +19,9 @@ jobs:
 
       # Gate auto-merge on the test suite passing, then merge.
       #
-      # We deliberately do NOT rely on branch protection / required status
-      # checks: fix-php-code-style-issues.yml and update-changelog.yml push
-      # directly to main via git-auto-commit-action, and required checks on
-      # main would block those pushes. Instead we wait for the test workflow
+      # main is protected (signed commits, linear history, PR required) but has
+      # NO required status checks, so branch protection alone won't keep an
+      # untested update out. We gate here instead: wait for the test workflow
       # run on this PR's head SHA to finish, and only merge if it succeeded.
       # Only semver-minor and semver-patch updates are auto-merged; majors
       # require manual review.


### PR DESCRIPTION
## What

Comment-only change to `dependabot-auto-merge.yml`. No behavioural change.

## Why

The rationale comment was out of date. It said:

> We deliberately do NOT rely on branch protection / required status checks: fix-php-code-style-issues.yml and update-changelog.yml push directly to main via git-auto-commit-action...

None of that holds anymore:

- The style workflow runs `contents: read` with `testMode: true` — it's check-only and never pushes.
- The changelog update is PR-based (`peter-evans/create-pull-request`), not a direct push.
- `main` is protected (signed commits, linear history, PR required).

The comment now states the real reason the test gate lives in the workflow: `main` has **no required status checks**, so branch protection can't keep an untested update out on its own — the workflow polls the test run for the PR head and only merges on success.

The merge step itself (which already passes `--match-head-commit` to avoid merging a rebased, untested head) is unchanged.