### PR TITLE
ci: set persist-credentials: false on checkout steps

### DIFF
--- a/.github/workflows/composer-security.yml
+++ b/.github/workflows/composer-security.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup PHP + pinned Composer
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check PHP code style (fail on violations, no changes)
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
+          persist-credentials: false
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1


### PR DESCRIPTION
## What

Set `persist-credentials: false` on every `actions/checkout` step across the CI and release workflows.

## Why

By default `actions/checkout` writes the job token into the workspace `.git/config` as an auth header. Persisting it only widens the attack surface: any later step in the same job (a compromised action, or a malicious transitive dependency pulled in during install) could read the token from disk. Setting `persist-credentials: false` keeps it out of the checkout and shrinks the blast radius.

## Scope

Now includes the release changelog workflow. That job pushes its branch via `create-pull-request`, which authenticates with the `token` it is given as an input rather than the credentials persisted by checkout, so `persist-credentials: false` is the recommended setup there (it also ensures the action's own token, not the one baked into git config by checkout, is used for the push).
